### PR TITLE
Update tsconfig.json paths to include contrib helpers

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "paths": {
-      "@/*": ["node_modules/hexabot/src/*", "modules/*"]
+      "@/*": ["node_modules/hexabot/src/*", "modules/*"],
+      "@/contrib/extensions/helpers/*": ["node_modules/*"]
     }
   },
   "include": ["modules/**/*.ts", "extensions/**/*.ts", "node_modules/hexabot/**/*.d.ts"]


### PR DESCRIPTION
Enhance the TypeScript configuration by adding paths for contrib extensions helpers to improve module resolution.

`@/contrib/extensions/helpers/*` : Points to `node_modules/*` to include helper extensions.