### PR TITLE
Update .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -34,7 +34,11 @@ MONGO_PASSWORD=dev_only
 MONGO_URI=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/
 MONGO_DB=hexabot
 
-# SMTP Config (for local dev env, use smtp4dev by doing `npx hexabot start --enable=smtp4dev`)
+# SMTP Config (for local dev environment).
+# For local development, it's recommended to use a mock SMTP server like smtp4dev.
+# 1. Add smtp4dev docker compose file (if needed): If you don't have it, add the smtp4dev docker compose file to the `docker` folder.  
+# A sample file can be found here: https://github.com/Hexastack/Hexabot/blob/main/docker/docker-compose.smtp4dev.yml
+# 2. Start smtp4dev service:  You can do this by running `hexabot start --services=smtp4dev`.  This assumes you have the smtp4dev docker compose file.
 APP_SMTP_4_DEV_PORT=9002
 EMAIL_SMTP_ENABLED=false
 EMAIL_SMTP_HOST=smtp4dev


### PR DESCRIPTION
This pull request includes an update to the `docker/.env.example` file to improve the documentation for setting up SMTP for local development. The most important change is the addition of detailed instructions for using a mock SMTP server like smtp4dev.

Documentation improvements:

* [`docker/.env.example`](diffhunk://#diff-ec10582dde9af6c0c622084d3244b29d496260613491c430ec8958565e2f31b4L37-R41): Added detailed instructions for setting up and using smtp4dev for local development. This includes adding a docker compose file for smtp4dev and starting the service using `hexabot start --services=smtp4dev`.