### PR TITLE
Add admin UI URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ hexabot dev
 
 The CLI creates `.env`, asks for the first admin credentials, installs dependencies, and starts local development with SQLite.
 
+The admin UI runs at `http://localhost:3000`.
+
 If you run this template directly, edit `SEED_ADMIN_*` in `.env` before the first startup.
 
 ## What You Can Build Here


### PR DESCRIPTION
### Motivation
- Clarify where the admin UI is served for local development by documenting the default URL.

### Description
- Add a single line to `README.md` noting that the admin UI runs at `http://localhost:3000`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07c5a7e58832dbf3499237356a0e2)