### PR TITLE
Add Vercel AI SDK dependencies for Gemini, Anthropic, Groq and Mistral

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,12 @@
         "dotenv": "^16.4.5",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "ai": "^5.0.91",
+        "@ai-sdk/anthropic": "^3.0.53",
+        "@ai-sdk/google": "^2.0.25",
+        "@ai-sdk/groq": "^2.0.25",
+        "@ai-sdk/mistral": "^2.0.25"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.10",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
     "dotenv": "^16.4.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "ai": "^5.0.91",
+    "@ai-sdk/anthropic": "^3.0.53",
+    "@ai-sdk/google": "^2.0.25",
+    "@ai-sdk/groq": "^2.0.25",
+    "@ai-sdk/mistral": "^2.0.25"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.10",


### PR DESCRIPTION
### Motivation
- Add direct Vercel AI SDK provider deps so the app can target popular non-OpenAI LLMs (Google Gemini, Anthropic/Claude, Groq, Mistral) via the Vercel `ai` ecosystem. 
- Keep OpenAI and any custom gateway usage handled by the existing `@hexabot-ai/api` core dependency.

### Description
- Added the following dependencies to `package.json`: `ai@^5.0.91`, `@ai-sdk/anthropic@^3.0.53`, `@ai-sdk/google@^2.0.25`, `@ai-sdk/groq@^2.0.25`, and `@ai-sdk/mistral@^2.0.25`.
- Updated `package-lock.json` root `packages[""] .dependencies` metadata to include the same entries so the lockfile reflects the new direct deps.
- Did not alter existing runtime code or configuration; this change only adjusts package metadata to enable installing the Vercel AI SDKs when registry access is available.

### Testing
- Ran `npm install ai @ai-sdk/google @ai-sdk/anthropic @ai-sdk/groq @ai-sdk/mistral`, which failed with `403 Forbidden` from the npm registry, so packages could not be fetched in this environment.
- Ran `npm install --package-lock-only` to regenerate the lockfile, which also failed with `403 Forbidden`, so full lockfile resolution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f0795ed8832daab56a03b061d2aa)