### PR TITLE
chore: bump @hexabot-ai/api to ^3.2.2-alpha.2 and @nestjs/cli to ^11.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "FCL-1.0-ALv2",
       "dependencies": {
-        "@hexabot-ai/api": "^3.2.2-alpha.1",
+        "@hexabot-ai/api": "^3.2.2-alpha.2",
         "@nestjs/common": "^11.1.6",
         "@nestjs/core": "^11.1.6",
         "@nestjs/platform-express": "^11.1.6",
@@ -24,7 +24,7 @@
         "@ai-sdk/mistral": "^2.0.25"
       },
       "devDependencies": {
-        "@nestjs/cli": "^11.0.10",
+        "@nestjs/cli": "^11.1.6",
         "@types/node": "^20.3.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:prod": "node dist/main"
   },
   "dependencies": {
-    "@hexabot-ai/api": "^3.2.2-alpha.1",
+    "@hexabot-ai/api": "^3.2.2-alpha.2",
     "@nestjs/common": "^11.1.6",
     "@nestjs/core": "^11.1.6",
     "@nestjs/platform-express": "^11.1.6",
@@ -27,7 +27,7 @@
     "@ai-sdk/mistral": "^2.0.25"
   },
   "devDependencies": {
-    "@nestjs/cli": "^11.0.10",
+    "@nestjs/cli": "^11.1.6",
     "@types/node": "^20.3.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
### Motivation
- Keep the starter template aligned with the published Hexabot API release and the current Nest 11 toolset by updating the dependency ranges.

### Description
- Updated `package.json` and the root metadata in `package-lock.json` to set `@hexabot-ai/api` to `^3.2.2-alpha.2` and `@nestjs/cli` to `^11.1.6`.

### Testing
- Attempted `npm view @hexabot-ai/api ...` and `npm view @nestjs/* ...` but registry queries failed with a `403 Forbidden`, and `npm run build` failed because `nest` is not installed in this environment, so no local install/build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2827b944c832d82c55b0e77333a3b)