### PR TITLE
Update @hexabot-ai/api to ^3.2.2-alpha.2 and @nestjs/cli to ^11.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "FCL-1.0-ALv2",
       "dependencies": {
-        "@hexabot-ai/api": "^3.2.2-alpha.1",
+        "@hexabot-ai/api": "^3.2.2-alpha.2",
         "@nestjs/common": "^11.1.6",
         "@nestjs/core": "^11.1.6",
         "@nestjs/platform-express": "^11.1.6",
@@ -24,7 +24,7 @@
         "@ai-sdk/mistral": "^2.0.25"
       },
       "devDependencies": {
-        "@nestjs/cli": "^11.0.10",
+        "@nestjs/cli": "^11.0.21",
         "@types/node": "^20.3.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:prod": "node dist/main"
   },
   "dependencies": {
-    "@hexabot-ai/api": "^3.2.2-alpha.1",
+    "@hexabot-ai/api": "^3.2.2-alpha.2",
     "@nestjs/common": "^11.1.6",
     "@nestjs/core": "^11.1.6",
     "@nestjs/platform-express": "^11.1.6",
@@ -27,7 +27,7 @@
     "@ai-sdk/mistral": "^2.0.25"
   },
   "devDependencies": {
-    "@nestjs/cli": "^11.0.10",
+    "@nestjs/cli": "^11.0.21",
     "@types/node": "^20.3.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
### Motivation
- Update `@hexabot-ai/api` and `@nestjs/cli` to newer released versions to pick up fixes and improvements.

### Description
- Updated `package.json` and `package-lock.json` to set `@hexabot-ai/api` to `^3.2.2-alpha.2` and the devDependency `@nestjs/cli` to `^11.0.21`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2827b944c832d82c55b0e77333a3b)