### PR TITLE
chore: set @nestjs/cli version range to ^11.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@ai-sdk/mistral": "^2.0.25"
       },
       "devDependencies": {
-        "@nestjs/cli": "^11.1.6",
+        "@nestjs/cli": "^11.0.21",
         "@types/node": "^20.3.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ai-sdk/mistral": "^2.0.25"
   },
   "devDependencies": {
-    "@nestjs/cli": "^11.1.6",
+    "@nestjs/cli": "^11.0.21",
     "@types/node": "^20.3.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
### Motivation
- Align the root dev dependency to the desired `@nestjs/cli` range and keep the lockfile consistent with `package.json`.

### Description
- Update the `@nestjs/cli` entry from `^11.1.6` to `^11.0.21` in `package.json` and the corresponding root `devDependencies` entry in `package-lock.json`.

### Testing
- Ran `git status --short` and committed the changes with `git commit`, both commands completed successfully; no runtime tests were executed for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f285f75ed4832d841336c5df1a8d4e)